### PR TITLE
Use valid category in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,6 +4,6 @@ author=Argentina Developers
 maintainer=Argentina Developers <argentina.developers@gmail.com>
 sentence=Control things with a secure password
 paragraph=This librarie uses the HC-05 or HC-06 and an android phone to command something, with bluetooth and password.
-category=Comunication
+category=Communication
 url=https://github.com/ArgentinaDevelopers/Arduino-Bluetooth-Control-with-password
 architectures=*


### PR DESCRIPTION
The previous `category` value caused the warning:
```
WARNING: Category 'Comunication' in library Bluetooth Control with password is not valid. Setting to 'Uncategorized'
```
List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format